### PR TITLE
Enable NFS in firewalld

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,6 +104,14 @@
     zone: public
   notify: reload service firewalld
 
+- name: Open NFS port
+  ansible.posix.firewalld:
+    service: nfs
+    permanent: true
+    state: enabled
+    zone: public
+  notify: reload service firewalld
+
 - name: Start and enable htcondor service
   ansible.builtin.service:
     name: condor


### PR DESCRIPTION

My tests reveal that NFS traffic needs to be also enabled in `firewalld`.