### PR TITLE
Add options to decide whether the role should manage the firewall configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,3 +37,8 @@ htcondor_server: "{{ ansible_fqdn }}"
 
 # Default ssh user
 htcondor_ssh_user: condoruser
+
+# Firewall configuration:
+# Open firewall ports for HTCondor and NFS
+htcondor_firewall_condor: true
+htcondor_firewall_nfs: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -95,6 +95,7 @@
     name:
       - firewalld
     state: present
+  when: htcondor_firewall_condor or htcondor_firewall_nfs
 
 - name: Open port 9618 for use by HTCondor
   ansible.posix.firewalld:
@@ -103,6 +104,7 @@
     state: enabled
     zone: public
   notify: reload service firewalld
+  when: htcondor_firewall_condor
 
 - name: Open NFS port
   ansible.posix.firewalld:
@@ -111,6 +113,7 @@
     state: enabled
     zone: public
   notify: reload service firewalld
+  when: htcondor_firewall_nfs
 
 - name: Start and enable htcondor service
   ansible.builtin.service:


### PR DESCRIPTION
Add options `htcondor_firewall_condor` and `htcondor_firewall_nfs` to control whether the HTCondor and NFS ports should be opened.