### PR TITLE
Update default value for htcondor_channel

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ htcondor_version: 10.x
 # Example values:
 #   current
 #   stable
-htcondor_channel: current
+htcondor_channel: 10.x
 
 # Domain config
 # https://htcondor.readthedocs.io/en/latest/users-manual/submitting-a-job.html#submitting-jobs-using-a-shared-file-system


### PR DESCRIPTION

Trying to fix the error that I am getting today:

```bash
TASK [grycap.htcondor : Add HTCondor GPG key] **********************************
Monday 09 October 2023 14:20:55.912660
changed: [147.213.76.176_0]

TASK [grycap.htcondor : Add YUM repository for HTCondor] ***********************
Monday 09 October 2023 14:20:58.984766
fatal: [147.213.76.176_0]: FAILED! => {"changed": false, "msg": "Failed to validate GPG signature for htcondor-release-23.x-1.el9.noarch"}
```

Possibly related to: https://www-auth.cs.wisc.edu/lists/htcondor-world/2023/msg00027.shtml