### PR TITLE
ensure right permissions for token files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,3 +34,6 @@ htcondor_server: "{{ ansible_fqdn }}"
 
 # Default ssh user
 htcondor_ssh_user: condoruser
+
+# Token Permissions
+htcondor_token_permissions: '0600'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,6 +90,20 @@
   args:
     creates: "{{ directory.stdout }}/condor@{{ htcondor_server }}"
 
+- name: Find token files
+  ansible.builtin.find:
+    paths: "{{ directory.stdout }}"
+    file_type: file
+    recurse: yes
+  register: htcondor_token_files
+
+- name: Ensure token permissions (400|600|700)
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    mode: "{{ htcondor_token_permissions }}"
+  notify: restart htcondor
+  loop: "{{ htcondor_token_files.files }}"
+
 - name: Is firewalld installed?
   ansible.builtin.package:
     name:


### PR DESCRIPTION
Recently we upgraded the htcondor from version 23 to 25. This meant that we needed to deal with the "recent" change of token permissions. 

Output of `condor_upgrade_check -v`:
```
Checking Token Permissions [TOK-PERM]:

    Found 1 token related thing(s) with incorrect ownership
    or file permissions. Expected:
        - Token Directories-> root:700
        - Token Files-------> root:400|600|700

    FILE> /etc/condor/tokens.d/condor@<redacted>
          * Invalid permissions (644): Requires (400|600|700)
        Check Token Permissions [TOK-PERM] failed
``` 
I added two tasks that iterates over the tokens directory and fixes the file permissions if needed. Let me know if this is relevant for the role